### PR TITLE
[docs] changes needed for mandel.cdt docs generation

### DIFF
--- a/scripts/clean_gen_docs.sh
+++ b/scripts/clean_gen_docs.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# This script is destructive. It deletes the doc build folder altogether.
+# It initialized web documentation.
+# It creates diretory structure when dirs do not exist
+# It copies over a few static web files (html, css, js)
+# created August 2022
+# author @iamveritas
+
+########
+# FUNCTIONS
+Help() {
+  echo "DELETES the specified directory!"
+  echo "Then it creates directories and installs initial templates."
+  echo "Creates web version of documentation pulling together documentation from several gitrepositories across the EOS Networks."
+  echo ""
+  echo "Syntax: clean_gen_docs [-h|d]"
+  echo "options:"
+  echo "-h: print this help"
+  echo "-d: specificy web root directory and destination"
+  exit 1
+}
+
+########
+# Get the options
+while getopts "hd:" option; do
+   case $option in
+      h) # display Help
+         Help
+         ;;
+      d) # set dir
+        ROOT_DIR=${OPTARG}
+        ;;
+      :) # no args
+        echo "missing '-d' directory, '-h' for help"; exit 1;
+        ;;
+      *) # abnormal args
+        echo "unexpected arguments, '-h' for help"; exit 1;
+        ;;
+   esac
+done
+
+######
+# main
+# check for parameters
+if [ -z $ROOT_DIR ]; then
+  echo "missing '-d' directory, '-h' for help"; exit 1;
+fi
+
+echo "delete directory ${ROOT_DIR}"
+
+rm -rf "${ROOT_DIR}"
+
+# compute script dir for copying files from here to web directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
+echo "change dir to ${SCRIPT_DIR}"
+
+pushd "${SCRIPT_DIR}"
+
+pwd
+
+echo "run ./initialize_repository.sh -d ${ROOT_DIR}"
+./initialize_repository.sh -d "${ROOT_DIR}"
+
+echo "run ./run_me_to_gen_docs.sh -u -d "${ROOT_DIR}""
+./run_me_to_gen_docs.sh -u -d "${ROOT_DIR}"
+
+echo "Done"
+
+popd

--- a/scripts/clean_gen_docs.sh
+++ b/scripts/clean_gen_docs.sh
@@ -58,12 +58,12 @@ echo "change dir to ${SCRIPT_DIR}"
 
 pushd "${SCRIPT_DIR}"
 
-pwd
+printf "Currently working in: %s" $(pwd)
 
 echo "run ./initialize_repository.sh -d ${ROOT_DIR}"
 ./initialize_repository.sh -d "${ROOT_DIR}"
 
-echo "run ./run_me_to_gen_docs.sh -u -d "${ROOT_DIR}""
+echo "run ./run_me_to_gen_docs.sh -u -d ${ROOT_DIR}"
 ./run_me_to_gen_docs.sh -u -d "${ROOT_DIR}"
 
 echo "Done"

--- a/scripts/generate_mandel-cdt.sh
+++ b/scripts/generate_mandel-cdt.sh
@@ -42,15 +42,10 @@ GenCDTDoc() {
   cp -R doxygen_out/html/* $DEST_DIR
 
   mkdir markdown_out
-  mv README.md markdown_out
-  mv LICENSE markdown_out/LICENSE.md
-  # quick fix to path for License
-  sed 's/\.\/LICENSE/\/eosdocs\/smart-contracts\/mandel-cdt\/LICENSE.md/' markdown_out/README.md > tmp_README.md
-  mv tmp_README.md markdown_out/README.md
 
   # pull in markdown docs from git
   cp -R docs/* markdown_out
   # copy into serving location
   # too many issues to fix ....
-  # cp -R markdown_out/* $DOC_DIR
+  cp -R markdown_out/* $DOC_DIR
 }

--- a/scripts/generate_mandel-cdt.sh
+++ b/scripts/generate_mandel-cdt.sh
@@ -19,7 +19,7 @@ GenCDTDoc() {
   SCRIPT_DIR=$2
   WORKING_DIR="${SCRIPT_DIR}/../working"
   # repo, use personal until pull request accepted
-  GIT_URL="https://github.com/eosnetworkfoundation/mandel.cdt"
+  GIT_URL="-b docs/cdt_md_fixes https://github.com/eosnetworkfoundation/mandel.cdt"
   # location of markdown docs inside repo
   DOC_PATH="docs"
 

--- a/scripts/mandle.cdt-doxyfile
+++ b/scripts/mandle.cdt-doxyfile
@@ -906,7 +906,9 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = libraries/eosiolib/contracts/eosio/
+INPUT                  = libraries/eosiolib/contracts/eosio/  \
+                         libraries/eosiolib/core/ \
+                         libraries/eosiolib/capi/
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
## Change Description
1. README.md and LICENSE.md filles are not needed
2. add the copy step which brings over all the docs content from mandel.cdt to local markdown folder
3. add a new shell script which is running all steps: delete, init, create folders, copy, generate
4.  add capi and core folders to be processed by doxygen